### PR TITLE
Update api call conditions for unlocked device

### DIFF
--- a/app/src/main/java/hu/rezsekmv/cameracontroller/data/PreferencesRepository.kt
+++ b/app/src/main/java/hu/rezsekmv/cameracontroller/data/PreferencesRepository.kt
@@ -20,7 +20,7 @@ data class CameraSettings(
     val getConfigPath: String,
     val setConfigPath: String,
     val timeoutSeconds: String,
-    val wifiName: String
+    val gatewayIp: String
 )
 
 class PreferencesRepository(private val context: Context) {
@@ -32,7 +32,7 @@ class PreferencesRepository(private val context: Context) {
         private val GET_CONFIG_PATH_KEY = stringPreferencesKey("get_config_path")
         private val SET_CONFIG_PATH_KEY = stringPreferencesKey("set_config_path")
         private val TIMEOUT_SECONDS_KEY = stringPreferencesKey("timeout_seconds")
-        private val WIFI_NAME_KEY = stringPreferencesKey("wifi_name")
+        private val GATEWAY_IP_KEY = stringPreferencesKey("gateway_ip")
     }
     
     val cameraSettings: Flow<CameraSettings> = context.dataStore.data.map { preferences ->
@@ -43,7 +43,7 @@ class PreferencesRepository(private val context: Context) {
             getConfigPath = preferences[GET_CONFIG_PATH_KEY] ?: "/cgi-bin/configManager.cgi?action=getConfig&name=MotionDetect",
             setConfigPath = preferences[SET_CONFIG_PATH_KEY] ?: "/cgi-bin/configManager.cgi?action=setConfig&MotionDetect[].Enable=",
             timeoutSeconds = preferences[TIMEOUT_SECONDS_KEY] ?: "2",
-            wifiName = preferences[WIFI_NAME_KEY] ?: ""
+            gatewayIp = preferences[GATEWAY_IP_KEY] ?: ""
         )
     }
     
@@ -83,15 +83,15 @@ class PreferencesRepository(private val context: Context) {
         }
     }
     
-    suspend fun updateWifiName(wifiName: String) {
+    suspend fun updateGatewayIp(gatewayIp: String) {
         context.dataStore.edit { preferences ->
-            preferences[WIFI_NAME_KEY] = wifiName
+            preferences[GATEWAY_IP_KEY] = gatewayIp
         }
     }
-    
-    fun getWifiName(): String {
+
+    fun getGatewayIp(): String {
         return runBlocking {
-            cameraSettings.first().wifiName
+            cameraSettings.first().gatewayIp
         }
     }
 }

--- a/app/src/main/java/hu/rezsekmv/cameracontroller/ui/CameraControlScreen.kt
+++ b/app/src/main/java/hu/rezsekmv/cameracontroller/ui/CameraControlScreen.kt
@@ -65,7 +65,7 @@ fun CameraControlScreen(
     var localGetConfigPath by remember { mutableStateOf(uiState.getConfigPath) }
     var localSetConfigPath by remember { mutableStateOf(uiState.setConfigPath) }
     var localTimeoutSeconds by remember { mutableStateOf(uiState.timeoutSeconds) }
-    var localWifiName by remember { mutableStateOf(uiState.wifiName) }
+    var localGatewayIp by remember { mutableStateOf(uiState.gatewayIp) }
     
     // Update local state when uiState changes (from DataStore)
     LaunchedEffect(uiState.username) { localUsername = uiState.username }
@@ -74,7 +74,7 @@ fun CameraControlScreen(
     LaunchedEffect(uiState.getConfigPath) { localGetConfigPath = uiState.getConfigPath }
     LaunchedEffect(uiState.setConfigPath) { localSetConfigPath = uiState.setConfigPath }
     LaunchedEffect(uiState.timeoutSeconds) { localTimeoutSeconds = uiState.timeoutSeconds }
-    LaunchedEffect(uiState.wifiName) { localWifiName = uiState.wifiName }
+    LaunchedEffect(uiState.gatewayIp) { localGatewayIp = uiState.gatewayIp }
 
     // Removed automatic API call on startup - user can manually refresh if needed
     
@@ -259,23 +259,23 @@ fun CameraControlScreen(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        val wifiNameInteractionSource = remember { MutableInteractionSource() }
-        val isWifiNameFocused by wifiNameInteractionSource.collectIsFocusedAsState()
+        val gatewayIpInteractionSource = remember { MutableInteractionSource() }
+        val isGatewayIpFocused by gatewayIpInteractionSource.collectIsFocusedAsState()
         
-        LaunchedEffect(isWifiNameFocused) {
-            if (!isWifiNameFocused) {
-                saveFieldOnFocusOut(localWifiName, uiState.wifiName, viewModel::updateWifiName)
+        LaunchedEffect(isGatewayIpFocused) {
+            if (!isGatewayIpFocused) {
+                saveFieldOnFocusOut(localGatewayIp, uiState.gatewayIp, viewModel::updateGatewayIp)
             }
         }
         
         OutlinedTextField(
-            value = localWifiName,
-            onValueChange = { localWifiName = it },
-            label = { Text("WiFi Network Name (starts with)") },
-            placeholder = { Text("MyHome") },
+            value = localGatewayIp,
+            onValueChange = { localGatewayIp = it },
+            label = { Text("Gateway IP") },
+            placeholder = { Text("192.168.1.1") },
             modifier = Modifier.fillMaxWidth(),
             singleLine = true,
-            interactionSource = wifiNameInteractionSource
+            interactionSource = gatewayIpInteractionSource
         )
 
         Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/hu/rezsekmv/cameracontroller/ui/CameraControlViewModel.kt
+++ b/app/src/main/java/hu/rezsekmv/cameracontroller/ui/CameraControlViewModel.kt
@@ -25,7 +25,7 @@ data class CameraControlUiState(
     val getConfigPath: String = "/cgi-bin/configManager.cgi?action=getConfig&name=MotionDetect",
     val setConfigPath: String = "/cgi-bin/configManager.cgi?action=setConfig&MotionDetect[].Enable=",
     val timeoutSeconds: String = "2",
-    val wifiName: String = "",
+    val gatewayIp: String = "",
     val motionDetectionStatus: MotionDetectionStatus = MotionDetectionStatus(null, false),
     val isLoading: Boolean = false,
     val errorMessage: String? = null
@@ -56,7 +56,7 @@ class CameraControlViewModel(context: Context) : ViewModel() {
             getConfigPath = settings.getConfigPath,
             setConfigPath = settings.setConfigPath,
             timeoutSeconds = settings.timeoutSeconds,
-            wifiName = settings.wifiName,
+            gatewayIp = settings.gatewayIp,
             motionDetectionStatus = motionStatus,
             isLoading = loading,
             errorMessage = error
@@ -136,10 +136,10 @@ class CameraControlViewModel(context: Context) : ViewModel() {
         }
     }
     
-    fun updateWifiName(wifiName: String) {
-        Log.d(TAG, "Updating WiFi name to: $wifiName")
+    fun updateGatewayIp(gatewayIp: String) {
+        Log.d(TAG, "Updating Gateway IP to: $gatewayIp")
         viewModelScope.launch {
-            preferencesRepository.updateWifiName(wifiName)
+            preferencesRepository.updateGatewayIp(gatewayIp)
         }
     }
 


### PR DESCRIPTION
Restrict auto-refresh on device unlock to only occur when connected to a Wi-Fi network with a matching gateway IP, preventing unnecessary API calls.

---
<a href="https://cursor.com/background-agent?bcId=bc-06694be6-040c-41fc-af68-d28128be2b22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-06694be6-040c-41fc-af68-d28128be2b22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

